### PR TITLE
bugfix/add-email-extraction-from-name

### DIFF
--- a/lib/blame/index.js
+++ b/lib/blame/index.js
@@ -26,6 +26,16 @@ blame.prototype.getLastCommiter = function(repositoryURL, userslist) {
       });
     }
 
+    if(!guiltyMember) { //Some users use their emails as names. try that comparison
+      members.forEach(function(member) {
+        var regExp = /\<([^)]+)\>/,
+          matches = regExp.exec(authorName);
+        if(!!matches[1] && !!member.profile.email && member.profile.email === matches[1]) {
+          guiltyMember = member;
+        }
+      });
+    }
+
     if(!!guiltyMember) {
       deferred.resolve(guiltyMember);
     } else {


### PR DESCRIPTION
Add another test that try to find the user by mail if he include the …mail inside in his real name.